### PR TITLE
#16: Remove `*.example` files from published jar (closes #16)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,4 +45,6 @@ lazy val mailo = (project in file(".")).
     )
   )
 
-mappings in (Compile, packageBin) ~= { _.filter(!_._1.getName.endsWith(".conf")) }
+mappings in (Compile, packageBin) ~= { _.filter { n =>
+  !((n._1.getName.endsWith(".conf")) || n._1.getName.endsWith(".conf.example")) }
+}


### PR DESCRIPTION
Issue #16
## Test Plan

What I did:
- `sbt package`
- `unzip /mailo/target/scala-2.11/mailo_2.11-0.1.3.jar`
- `find . -name application.conf.example` returned nothing
  (same processes on master returns `./application.conf.example`)
